### PR TITLE
limit search window in current working space.

### DIFF
--- a/quickey.py
+++ b/quickey.py
@@ -41,14 +41,28 @@ def get_matched_window_ids(target_regexp, is_class):
     regexp_pattern = re.compile(target_regexp)
     wmctrl_option = "lx" if is_class else "l"
     wmctrl_list = exec_command("wmctrl -%s" % wmctrl_option).split('\n')
+    workspace_list = exec_command('wmctrl -d').split('\n')
+    curspace = get_curworkspace_number(workspace_list)
     ids = []
     for row in wmctrl_list:
         columns = split_columns_by_wmctrl_row(row)
+        curwork_bool = get_this_workspace(columns, curspace)
         title = get_title_by_columns(columns, is_class)
         search_target = get_wm_class_by_columns(columns) if is_class else title
         if not regexp_pattern.search(search_target): continue
+        if not curwork_bool: continue
         ids.append(columns[0])
     return ids;
+
+def get_this_workspace(wmcol, curspace):
+    if wmcol[1] == "-1" or wmcol[1] == curspace: return True
+    else: return False
+    
+def get_curworkspace_number(space_list):
+    work_num = ""
+    for col in space_list:
+      if "*" in col: work_num = col[0]
+    return work_num
 
 # Split to column by the row of "wmctrl -l[x]" command result.
 def split_columns_by_wmctrl_row(wmctrl_list_row):


### PR DESCRIPTION
複数のワークスペースで同じソフトを起動している場合quickkeyを使うと思わぬワークスペースへと遷移してしまうことがあるため、windowの検索対象を現在のワークスペースに限定してみました。

私の環境(linux mint 17.3 cinnamon)では問題なく動くようです。
